### PR TITLE
Migrated to gradle 1.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://github.com/sephiroth74/picasso' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.2.2'
     }
 }
 

--- a/circularImageView/build.gradle
+++ b/circularImageView/build.gradle
@@ -5,14 +5,14 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        applicationId "com.mikhaellopez.circularimageview"
+        //applicationId "com.mikhaellopez.circularimageview"
         minSdkVersion 11
         targetSdkVersion 19
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/dragsortlistviewlibrary/build.gradle
+++ b/dragsortlistviewlibrary/build.gradle
@@ -5,14 +5,14 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        applicationId "com.mobeta.android.dslv"
+        //applicationId "com.mobeta.android.dslv"
         minSdkVersion 10
         targetSdkVersion 19
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Sun Jul 12 19:56:04 ECT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/jamsMusicPlayer/build.gradle
+++ b/jamsMusicPlayer/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'android'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 21
+    buildToolsVersion '22.0.1'
 
     defaultConfig {
         applicationId "com.jams.music.player"
@@ -11,12 +11,12 @@ android {
 
         //RenderScript backward compatibility for guassian blurs.
         renderscriptTargetApi 19
-        renderscriptSupportMode true
+        renderscriptSupportModeEnabled true
     }
 
     buildTypes {
         release {
-            runProguard true
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
         }
     }
@@ -57,6 +57,7 @@ dependencies {
     compile files('libs/com.haarman.listviewanimations-2.6.0.jar')
     compile files('libs/nineoldandroids-2.4.0.jar')
     compile files('libs/renderscript-v8.jar')
-    compile 'com.android.support:support-v4:+'
-    compile 'com.google.android.gms:play-services:+'
+    compile 'com.android.support:support-v4:19.1.0'
+    compile "com.android.support:appcompat-v7:22.2.0"
+    compile 'com.google.android.gms:play-services:3.1.36'
 }

--- a/licensesdialoglibrary/build.gradle
+++ b/licensesdialoglibrary/build.gradle
@@ -5,14 +5,14 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        applicationId "de.psdev.licensesdialog"
+        //applicationId "de.psdev.licensesdialog"
         minSdkVersion 14
         targetSdkVersion 19
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '20.0.0'
 
     defaultConfig {
-        applicationId "com.squareup.picasso"
+        //applicationId "com.squareup.picasso"
         minSdkVersion 14
         targetSdkVersion 19
         versionCode 1
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/picasso/src/main/AndroidManifest.xml
+++ b/picasso/src/main/AndroidManifest.xml
@@ -4,6 +4,5 @@
     android:versionCode="1"
     android:versionName="2.3.2" >
 
-    <uses-sdk tools:node="replace" />
 
 </manifest>

--- a/quickScroll/build.gradle
+++ b/quickScroll/build.gradle
@@ -4,14 +4,14 @@ android {
     buildToolsVersion '20.0.0'
 
     defaultConfig {
-        applicationId "com.andraskindler.quickscroll"
+        //applicationId "com.andraskindler.quickscroll"
         minSdkVersion 14
         targetSdkVersion 19
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/velocityviewpagerlibrary/build.gradle
+++ b/velocityviewpagerlibrary/build.gradle
@@ -5,14 +5,14 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        applicationId "com.velocity.view.pager.library"
+        //applicationId "com.velocity.view.pager.library"
         minSdkVersion 14
         targetSdkVersion 19
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/viewpagerindicatorlibrary/build.gradle
+++ b/viewpagerindicatorlibrary/build.gradle
@@ -5,14 +5,14 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        applicationId "com.velocityviewpagerindicator"
+        //applicationId "com.velocityviewpagerindicator"
         minSdkVersion 4
         targetSdkVersion 4
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }


### PR DESCRIPTION
changed all occurrences of 'renderscriptSupportMode' to 'renderscriptSupportModeEnabled'.
changed all occurrences of 'runProguard' to 'minifyEnabled'.
deleted all occurences of 'applicationId' in modules' gradle files.

deleted all occurences of 'tools:node' in uses-sdk of manifest files.

deleted all occurences of 'applicationId' in modules' gradle files.
deleted al icons named ic_launcher in modules.

After doing all of this I could finally build Jams Music Player with my
computer. 0.12 seems a little outdated.
